### PR TITLE
feat: 行程地圖圖資套用與標記定位修正

### DIFF
--- a/src/components/map/NewTrpLightBox02.vue
+++ b/src/components/map/NewTrpLightBox02.vue
@@ -8,12 +8,12 @@
         </div>
         <div class="selections">
           <div class="drop-down-box" @click.stop="toggleDropdown('area')">
-            <div id="trp_area">{{ selectedArea }}</div>
+            <div id="trp_area">{{ areaMapping[selectedArea] }}</div>
             <font-awesome-icon :icon="['fas', 'chevron-down']" />
           </div>
           <ul v-if="showAreaDropdown" class="drop-down-list">
             <li v-for="(area, index) in areas" :key="index" @click="selectArea(area)">
-              {{ area }}
+              {{ areaMapping[area] }}
             </li>
           </ul>
         </div>
@@ -67,9 +67,15 @@
         endDate: '', // 結束日期
         endDateMin: '', // 結束日期的最小值
         isPublic: false, // 是否公開
-        areas: ['日本', '韓國', '泰國', '港澳'],
+        areas: ['jp', 'kr', 'th', 'cn'],
         showAreaDropdown: false,
-        selectedArea: '日本',
+        selectedArea: 'jp',
+        areaMapping: {
+          jp: '日本',
+          kr: '韓國',
+          cn: '港澳',
+          th: '泰國'
+        }
       };
     },
     methods: {


### PR DESCRIPTION
新增/調整以下功能：

- 行程地圖MapComponent根據載入時選擇的國家/地區會套用相應的圖資。
- 變更行程列中的景點項目上標示停留時間的樣式，並新增文字底線與cursor: pointer，以提示該文字可點擊。


修正以下問題：

- 現在地圖縮放後會自動校正地圖標記上的標記位置。
- 現在當點擊行程列中任一景點時，只會開啟該項景點的工具清單，不會所有清單同時開啟。