### PR TITLE
feat:行程包含各天數景點可存在本地端資料庫

### DIFF
--- a/src/components/layout/LoginRegisterBox.vue
+++ b/src/components/layout/LoginRegisterBox.vue
@@ -172,7 +172,7 @@ const login = async () => {
     formData.append('u_psw', password.value);
 
     try {
-        const response = await apiInstance.post('http://localhost/phpG6/front/login.php', formData, {
+        const response = await apiInstance.post('http://localhost/phpG6/api/login.php', formData, {
             headers: { 'Content-Type': 'multipart/form-data' }
         });
 

--- a/src/views/TripsView.vue
+++ b/src/views/TripsView.vue
@@ -8,6 +8,7 @@
       @edit-plan-setting="showTripSetting"
       @show-edit-stay-time="showEditStayTimeHandler"
       @save-stay-time="saveStayTimeHandler"
+      @save-trip-plan="handleSaveTripPlan"
     />
     <NewTrpLightBox02 :class="{ hidden: !showNewTrpLightBox02 }" @submit-trip="handleTripSubmit" />
     <BlackLayout :class="{ hidden: !showBlackLayout }" />
@@ -142,6 +143,31 @@ const saveStayTimeHandler = (formattedTime) => {
   selectedLocation.value.receivedStayTime = formattedTime;
 
   closeEditStayTime(); // 儲存完畢後關閉 EditStayTime 組件
+};
+//處理儲存行程事件與接收資料
+const handleSaveTripPlan = async (tripPlanData) => {
+  console.log('接收到的行程資料：', tripPlanData); // 確認 tripPlanData 的內容
+  try {
+    const response = await fetch('http://localhost/phpG6/api/saveTripPlan.php', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(tripPlanData),
+    });
+
+    const data = await response.json();
+    console.log('後端回應資料：', data); // 檢查後端回應的內容
+
+    if (data.status === 'success') {
+      alert('行程保存成功！');
+    } else {
+      alert('else:行程保存失敗，請重試。');
+    }
+  } catch (error) {
+    console.error('Error:', error);
+    alert('catch:行程保存失敗，請重試。');
+  }
 };
 
 // 在組件載入後顯示 MapGuide、NewTrpLightBox01 及 BlackLayout


### PR DESCRIPTION
新增與修改：
- 現在在登入狀態下，可以將行程儲存至本地端資料庫，包含天數、各天行程、停留時間。
- 目前的資料表結構有小問題(在trip_spot資料表中缺了day_num，會無法知道在該天行程中的景點次序)，下一個版本會再調整。
- 尚未設定如何存取照片檔路徑、存取的字串怎麼切。
- 尚未設定非會員狀態下只能單純瀏覽行程，以及行程資料從資料庫撈取後渲染。
- 就UX面來看，會需要加上判斷「每當行程有任何變更，按鈕就要變色」提示使用者資料未儲存。