### PR TITLE
feat: 行程儲存本地端時可儲存圖片及圖片名稱字串

### DIFF
--- a/src/components/layout/LoginRegisterBox.vue
+++ b/src/components/layout/LoginRegisterBox.vue
@@ -172,7 +172,7 @@ const login = async () => {
     formData.append('u_psw', password.value);
 
     try {
-        const response = await apiInstance.post('http://localhost/phpG6/api/login.php', formData, {
+        const response = await apiInstance.post(`${import.meta.env.VITE_API_URL}/login.php`, formData, {
             headers: { 'Content-Type': 'multipart/form-data' }
         });
 
@@ -253,7 +253,7 @@ const handleRegistration = async () => {
     formData.append('nickname', registerUsername.value); // 將使用者名稱作為暱稱
 
     try {
-        const response = await apiInstance.post('http://localhost/phpG6/api/register.php', formData, {
+        const response = await apiInstance.post(`${import.meta.env.VITE_API_URL}/register.php`, formData, {
             headers: { 'Content-Type': 'multipart/form-data' }
         });
         if (response.data.code === 1) {

--- a/src/views/TicketsView.vue
+++ b/src/views/TicketsView.vue
@@ -97,7 +97,7 @@ export default {
   methods: {
     async loadJsonData(){
       try {
-        const response = await fetch('http://localhost/phpG6/front/getTickets.php', { //使用fetch 發送請求
+        const response = await fetch('http://localhost/phpG6/api/getTickets.php', { //使用fetch 發送請求
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json' //設置headers 指定請求內容為json檔


### PR DESCRIPTION
現在儲存行程時可以同步將封面圖片儲存至images資料夾，並且將上傳的圖片名稱以uniqid編碼，避免重複命名。資料表中的trp_img欄位會儲存其檔案名稱字串。