### PR TITLE
fix: 調整導覽列「開始規劃」RWD顯示問題

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -380,9 +380,9 @@ header {
           display: none;
         }
 
-        // span.btn-start-plan {
-        // display: none;
-        // }
+        span.btn-start-plan {
+        display: none;
+        }
 
       }
     }
@@ -479,6 +479,9 @@ header {
         .router-wrapper {
           a {
             display: inline;
+          }
+          span.btn-start-plan {
+            display: block;
           }
 
           .memwrap {


### PR DESCRIPTION
在一般狀態下把橫向導覽列的「開始規劃」鈕設定為「有closed類別時display: hidden;」，在(min-width: 768px)狀態下，設為「有closed類別時必須display:block;」。